### PR TITLE
Remove vtgate lifecycle hooks

### DIFF
--- a/paasta_tools/vitesscluster_tools.py
+++ b/paasta_tools/vitesscluster_tools.py
@@ -104,6 +104,7 @@ VTTABLET_EXTRA_FLAGS = {
     "throttle_check_as_check_self": "true",
     "db_charset": "utf8mb4",
     "disable_active_reparents": "true",
+    "init_shard": "0",
 }
 
 
@@ -260,26 +261,6 @@ def get_cell_config(
     config = CellConfigDict(
         name=cell,
         gateway=GatewayConfigDict(
-            lifecycle={
-                "preStop": {
-                    "exec": {
-                        "command": [
-                            "/bin/sh",
-                            "-c",
-                            f"/cloudmap/scripts/deregister_from_cloudmap.sh vtgate-{cell} {aws_region}",
-                        ]
-                    }
-                },
-                "postStart": {
-                    "exec": {
-                        "command": [
-                            "/bin/sh",
-                            "-c",
-                            f"/cloudmap/scripts/register_to_cloudmap.sh vtgate-{cell} {aws_region}",
-                        ]
-                    }
-                },
-            },
             affinity={"nodeAffinity": node_affinity},
             extraEnv=updated_vtgate_extra_env,
             extraFlags={

--- a/tests/test_vitesscluster_tools.py
+++ b/tests/test_vitesscluster_tools.py
@@ -132,26 +132,6 @@ VITESS_CONFIG = {
                         "name": "etc-srv-configs",
                     },
                 ],
-                "lifecycle": {
-                    "postStart": {
-                        "exec": {
-                            "command": [
-                                "/bin/sh",
-                                "-c",
-                                "/cloudmap/scripts/register_to_cloudmap.sh vtgate-fake_cell mo-ck_r-e",
-                            ]
-                        }
-                    },
-                    "preStop": {
-                        "exec": {
-                            "command": [
-                                "/bin/sh",
-                                "-c",
-                                "/cloudmap/scripts/deregister_from_cloudmap.sh vtgate-fake_cell mo-ck_r-e",
-                            ]
-                        }
-                    },
-                },
                 "replicas": 1,
                 "resources": {
                     "limits": {"cpu": "100m", "memory": "256Mi"},
@@ -349,6 +329,7 @@ VITESS_CONFIG = {
                                             "enforce-tableacl-config": "true",
                                             "grpc_max_message_size": "134217728",
                                             "init_tablet_type": "replica",
+                                            "init_shard": "0",
                                             "keep_logs": "72h",
                                             "log_err_stacks": "true",
                                             "queryserver-config-schema-reload-time": "1800",
@@ -537,6 +518,7 @@ VITESS_CONFIG = {
                                             "enforce-tableacl-config": "true",
                                             "grpc_max_message_size": "134217728",
                                             "init_tablet_type": "replica",
+                                            "init_shard": "0",
                                             "keep_logs": "72h",
                                             "log_err_stacks": "true",
                                             "queryserver-config-schema-reload-time": "1800",


### PR DESCRIPTION
Remove vtgate lifecycle hooks as we're not proceeding with the fix https://github.com/Yelp/paasta/pull/3959 and would like to have functional vtgate pods for testing