### PR TITLE
DREIMP-10951: Autoscale VitessCell pods with HPA

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -871,6 +871,11 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         )
         return None
 
+    def get_autoscaling_target(self, name: str) -> V2beta2CrossVersionObjectReference:
+        return V2beta2CrossVersionObjectReference(
+            api_version="apps/v1", kind="Deployment", name=name
+        )
+
     def get_autoscaling_metric_spec(
         self,
         name: str,
@@ -926,9 +931,7 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 max_replicas=max_replicas,
                 min_replicas=min_replicas,
                 metrics=metrics,
-                scale_target_ref=V2beta2CrossVersionObjectReference(
-                    api_version="apps/v1", kind="Deployment", name=name
-                ),
+                scale_target_ref=self.get_autoscaling_target(name),
             ),
         )
 

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -871,11 +871,6 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         )
         return None
 
-    def get_autoscaling_target(self, name: str) -> V2beta2CrossVersionObjectReference:
-        return V2beta2CrossVersionObjectReference(
-            api_version="apps/v1", kind="Deployment", name=name
-        )
-
     def get_autoscaling_metric_spec(
         self,
         name: str,
@@ -931,7 +926,9 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
                 max_replicas=max_replicas,
                 min_replicas=min_replicas,
                 metrics=metrics,
-                scale_target_ref=self.get_autoscaling_target(name),
+                scale_target_ref=V2beta2CrossVersionObjectReference(
+                    api_version="apps/v1", kind="Deployment", name=name
+                ),
             ),
         )
 

--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -50,7 +50,9 @@ from paasta_tools.utils import get_git_sha_from_dockerurl
 from paasta_tools.utils import load_all_configs
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.vitesscell_tools import load_vitess_cell_instance_configs
-from paasta_tools.vitesscell_tools import update_vitess_cell_related_api_objects
+from paasta_tools.vitesscell_tools import (
+    update_related_api_objects as update_vitess_cell_related_api_objects,
+)
 from paasta_tools.vitesscell_tools import VITESSCELL_KUBERNETES_NAMESPACE
 from paasta_tools.vitesscluster_tools import load_vitess_cluster_instance_configs
 from paasta_tools.vitesscluster_tools import VITESSCLUSTER_KUBERNETES_NAMESPACE

--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -50,6 +50,7 @@ from paasta_tools.utils import get_git_sha_from_dockerurl
 from paasta_tools.utils import load_all_configs
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.vitesscell_tools import load_vitess_cell_instance_configs
+from paasta_tools.vitesscell_tools import update_vitess_cell_related_api_objects
 from paasta_tools.vitesscell_tools import VITESSCELL_KUBERNETES_NAMESPACE
 from paasta_tools.vitesscluster_tools import load_vitess_cluster_instance_configs
 from paasta_tools.vitesscluster_tools import VITESSCLUSTER_KUBERNETES_NAMESPACE
@@ -64,6 +65,11 @@ INSTANCE_TYPE_TO_CONFIG_LOADER = {
     "vitesscluster": load_vitess_cluster_instance_configs,
     "vitesscell": load_vitess_cell_instance_configs,
     "vitesskeyspace": load_vitess_keyspace_instance_configs,
+}
+
+
+INSTANCE_TYPE_TO_RELATED_OBJECTS_UPDATER = {
+    "vitesscell": update_vitess_cell_related_api_objects,
 }
 
 
@@ -444,6 +450,15 @@ def reconcile_kubernetes_resource(
                 )
             else:
                 log.info(f"{desired_resource} is up to date, no action taken")
+
+            if crd.file_prefix in INSTANCE_TYPE_TO_RELATED_OBJECTS_UPDATER:
+                INSTANCE_TYPE_TO_RELATED_OBJECTS_UPDATER[crd.file_prefix](
+                    service=service,
+                    instance=inst,
+                    cluster=cluster,
+                    kube_client=kube_client,
+                    soa_dir=DEFAULT_SOA_DIR,
+                )
         except Exception as e:
             log.error(str(e))
             succeeded = False

--- a/paasta_tools/vitesscell_tools.py
+++ b/paasta_tools/vitesscell_tools.py
@@ -345,7 +345,7 @@ def load_vitess_cell_instance_configs(
     return vitess_cell_instance_configs
 
 
-def update_vitess_cell_related_api_objects(
+def update_related_api_objects(
     service: str,
     instance: str,
     cluster: str,

--- a/paasta_tools/vitesscell_tools.py
+++ b/paasta_tools/vitesscell_tools.py
@@ -8,11 +8,19 @@ from typing import TypedDict
 from typing import Union
 
 import service_configuration_lib
+from kubernetes.client import V1ObjectMeta
+from kubernetes.client import V1OwnerReference
 from kubernetes.client import V2beta2CrossVersionObjectReference
+from kubernetes.client import V2beta2HorizontalPodAutoscaler
+from kubernetes.client import V2beta2HorizontalPodAutoscalerSpec
 
+from paasta_tools.kubernetes_tools import get_cr
 from paasta_tools.kubernetes_tools import KubeClient
 from paasta_tools.kubernetes_tools import KubernetesDeploymentConfigDict
+from paasta_tools.kubernetes_tools import paasta_prefixed
 from paasta_tools.kubernetes_tools import sanitised_cr_name
+from paasta_tools.long_running_service_tools import DEFAULT_AUTOSCALING_SETPOINT
+from paasta_tools.long_running_service_tools import METRICS_PROVIDER_CPU
 from paasta_tools.utils import BranchDictV2
 from paasta_tools.utils import deep_merge_dictionaries
 from paasta_tools.utils import DEFAULT_SOA_DIR
@@ -179,18 +187,56 @@ class VitessCellConfig(VitessDeploymentConfig):
             "rootPath": TOPO_GLOBAL_ROOT,
         }
 
-    def get_autoscaling_target(self, name: str) -> V2beta2CrossVersionObjectReference:
-        return V2beta2CrossVersionObjectReference(
-            api_version="planetscale.com/v2", kind="VitessCell", name=name
+    def get_desired_hpa(
+        self,
+        kube_client: KubeClient,
+        owner_uid: str,
+        min_replicas: Optional[int],
+        max_replicas: Optional[int],
+    ) -> Optional[V2beta2HorizontalPodAutoscaler]:
+        name = sanitised_cr_name(self.service, self.instance)
+        return V2beta2HorizontalPodAutoscaler(
+            kind="HorizontalPodAutoscaler",
+            metadata=V1ObjectMeta(
+                name=name,
+                namespace=self.get_namespace(),
+                annotations=dict(),
+                labels={
+                    paasta_prefixed("service"): self.service,
+                    paasta_prefixed("instance"): self.instance,
+                    paasta_prefixed("pool"): self.get_pool(),
+                    paasta_prefixed("managed"): "true",
+                },
+                owner_references=[
+                    V1OwnerReference(
+                        api_version="planetscale.com/v2",
+                        kind="VitessCell",
+                        name=name,
+                        uid=owner_uid,
+                        controller=True,
+                        block_owner_deletion=True,
+                    ),
+                ],
+            ),
+            spec=V2beta2HorizontalPodAutoscalerSpec(
+                behavior=self.get_autoscaling_scaling_policy(max_replicas, {}),
+                max_replicas=max_replicas,
+                min_replicas=min_replicas,
+                metrics=[
+                    self.get_autoscaling_provider_spec(
+                        name=name,
+                        namespace=self.get_namespace(),
+                        provider={
+                            "type": METRICS_PROVIDER_CPU,
+                            "setpoint": DEFAULT_AUTOSCALING_SETPOINT,
+                        },
+                    ),
+                ],
+                scale_target_ref=V2beta2CrossVersionObjectReference(
+                    api_version="planetscale.com/v2", kind="VitessCell", name=name
+                ),
+            ),
         )
-
-    def get_min_instances(self) -> Optional[int]:
-        vtgate_resources = self.config_dict.get("vtgate_resources")
-        return vtgate_resources.get("min_instances", 1)
-
-    def get_max_instances(self) -> Optional[int]:
-        vtgate_resources = self.config_dict.get("vtgate_resources")
-        return vtgate_resources.get("max_instances")
 
     def update_related_api_objects(
         self,
@@ -215,15 +261,18 @@ class VitessCellConfig(VitessDeploymentConfig):
         )
 
         if should_exist:
-            hpa = self.get_autoscaling_metric_spec(
-                name=name,
-                cluster=self.get_cluster(),
-                kube_client=kube_client,
-                namespace=self.get_namespace(),
-            )
-            if not hpa:
+            vitesscell_cr = get_cr(kube_client, cr_id(self.service, self.instance))
+            if not vitesscell_cr:
+                # We need the uid of the VitessCell CR to set the owner reference on the HPA.
                 return
 
+            owner_uid = vitesscell_cr["metadata"]["uid"]
+            hpa = self.get_desired_hpa(
+                kube_client=kube_client,
+                owner_uid=owner_uid,
+                min_replicas=min_instances,
+                max_replicas=max_instances,
+            )
             if exists:
                 kube_client.autoscaling.replace_namespaced_horizontal_pod_autoscaler(
                     name=name,

--- a/paasta_tools/vitesscell_tools.py
+++ b/paasta_tools/vitesscell_tools.py
@@ -400,7 +400,7 @@ def update_vitess_cell_related_api_objects(
     cluster: str,
     kube_client: KubeClient,
     soa_dir: str = DEFAULT_SOA_DIR,
-) -> VitessCellConfigDict:
+) -> None:
     load_vitess_cell_instance_config(
         service, instance, cluster, soa_dir=soa_dir
     ).update_related_api_objects(kube_client)

--- a/paasta_tools/vitesscell_tools.py
+++ b/paasta_tools/vitesscell_tools.py
@@ -67,7 +67,7 @@ class GatewayConfigDict(TypedDict, total=False):
     extraFlags: Dict[str, str]
     extraLabels: Dict[str, str]
     replicas: int
-    scale_selector: str
+    yelp_selector: str
     resources: Dict[str, Any]
     annotations: Mapping[str, Any]
 
@@ -124,7 +124,7 @@ def get_cell_config(
             },
             extraLabels=labels,
             replicas=replicas,
-            scale_selector=",".join([f"{k}={v}" for k, v in labels.items()]),
+            yelp_selector=",".join([f"{k}={v}" for k, v in labels.items()]),
             resources={
                 "requests": requests,
                 "limits": requests,

--- a/paasta_tools/vitesscluster_tools.py
+++ b/paasta_tools/vitesscluster_tools.py
@@ -73,6 +73,8 @@ class RequestsDict(TypedDict, total=False):
 
 class ResourceConfigDict(TypedDict, total=False):
     replicas: int
+    min_instances: Optional[int]
+    max_instances: Optional[int]
     requests: Dict[str, RequestsDict]
     limits: Dict[str, RequestsDict]
 


### PR DESCRIPTION
# Problem

We'd like to autoscale the vtgate deployments created by the vitess-operator for each VitessCell.

# Solution

Create an HPA for each VitessCell, where max_instances is set.

This PR should be merged after https://github.com/Yelp/paasta/pull/3940

# Context

- The VitessCell CRD should be changed as well: https://github.yelpcorp.com/misc/compute-infra-k8s/pull/1949
- Example autoscaled instance: https://github.yelpcorp.com/sysgit/yelpsoa-configs/pull/48782


http://y/DREIMP-10951