### PR TITLE
Speed up the default preStop hook to allow for graceful shutdown

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -1472,7 +1472,10 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         if not command:
             return V1Handler(
                 _exec=V1ExecAction(
-                    command=["/bin/sh", "-c", f"sleep {DEFAULT_PRESTOP_SLEEP_SECONDS}"]
+                    # NOTE: we could also probably look into seeing what happens if we return None
+                    # instead of a V1Handler, but in the meantime, having a funny message as the pre-stop
+                    # hook doesn't seem particularly harmful
+                    command=["/bin/sh", "-c", f"echo Goodbye, cruel world."]
                 )
             )
         if isinstance(command, str):

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -930,7 +930,9 @@ class TestKubernetesDeploymentConfig:
                     image=mock_get_docker_url.return_value,
                     lifecycle=V1Lifecycle(
                         pre_stop=V1Handler(
-                            _exec=V1ExecAction(command=["/bin/sh", "-c", "sleep 30"])
+                            _exec=V1ExecAction(
+                                command=["/bin/sh", "-c", "echo Goodbye, cruel world."]
+                            )
                         )
                     ),
                     liveness_probe=V1Probe(
@@ -2187,9 +2189,18 @@ class TestKubernetesDeploymentConfig:
     @pytest.mark.parametrize(
         "termination_action,expected",
         [
-            (None, ["/bin/sh", "-c", "sleep 30"]),  # no termination action
-            ("", ["/bin/sh", "-c", "sleep 30"]),  # empty termination action
-            ([], ["/bin/sh", "-c", "sleep 30"]),  # empty termination action
+            (
+                None,
+                ["/bin/sh", "-c", "echo Goodbye, cruel world."],
+            ),  # no termination action
+            (
+                "",
+                ["/bin/sh", "-c", "echo Goodbye, cruel world."],
+            ),  # empty termination action
+            (
+                [],
+                ["/bin/sh", "-c", "echo Goodbye, cruel world."],
+            ),  # empty termination action
             ("/bin/no-args", ["/bin/no-args"]),  # no args command
             (["/bin/bash", "cmd.sh"], ["/bin/bash", "cmd.sh"]),  # no args command
         ],
@@ -4274,7 +4285,7 @@ def test_warning_big_bounce():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "config5abf6b07"
+            == "config7d73e761"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 
@@ -4320,7 +4331,7 @@ def test_warning_big_bounce_routable_pod():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "config8ee1bd70"
+            == "config17bb62ea"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every smartstack-registered service to bounce!"
 
 


### PR DESCRIPTION
The default PaaSTA preStop hook sleeps for 30s - which is exactly the same as the default termination grace period, therefore preventing anything that gets this default hook from being able to gracefully shutdown.

We could (should?) look into simply not adding a hook for things that don't need one (i.e., not mesh-registed and no custom hooks), but in the meantime adding a silly message doesn't seem particularly harmful.