### PR TITLE
Add support for autotune limits in service_shard_update

### DIFF
--- a/paasta_tools/contrib/service_shard_update.py
+++ b/paasta_tools/contrib/service_shard_update.py
@@ -274,26 +274,56 @@ def main(args):
                         instance_config["cpus"] = args.cpus
                     if args.mem is not None:
                         instance_config["mem"] = args.mem
-                    if any((args.autotune_min_cpus, args.autotune_max_cpus, args.autotune_min_mem, args.autotune_max_mem, args.autotune_min_disk, args.autotune_max_disk)):
+                    if any(
+                        (
+                            args.autotune_min_cpus,
+                            args.autotune_max_cpus,
+                            args.autotune_min_mem,
+                            args.autotune_max_mem,
+                            args.autotune_min_disk,
+                            args.autotune_max_disk,
+                        )
+                    ):
                         instance_config["autotune"] = {}
-                        if args.autotune_min_cpus is not None or args.autotune_max_cpus is not None:
+                        if (
+                            args.autotune_min_cpus is not None
+                            or args.autotune_max_cpus is not None
+                        ):
                             instance_config["autotune"]["cpus"] = {}
                             if args.autotune_min_cpus is not None:
-                                instance_config["autotune"]["cpus"]["min"] = args.autotune_min_cpus
+                                instance_config["autotune"]["cpus"][
+                                    "min"
+                                ] = args.autotune_min_cpus
                             if args.autotune_max_cpus is not None:
-                                instance_config["autotune"]["cpus"]["max"] = args.autotune_max_cpus
-                        if args.autotune_min_mem is not None or args.autotune_max_mem is not None:
+                                instance_config["autotune"]["cpus"][
+                                    "max"
+                                ] = args.autotune_max_cpus
+                        if (
+                            args.autotune_min_mem is not None
+                            or args.autotune_max_mem is not None
+                        ):
                             instance_config["autotune"]["mem"] = {}
                             if args.autotune_min_mem is not None:
-                                instance_config["autotune"]["mem"]["min"] = args.autotune_min_mem
+                                instance_config["autotune"]["mem"][
+                                    "min"
+                                ] = args.autotune_min_mem
                             if args.autotune_max_mem is not None:
-                                instance_config["autotune"]["mem"]["max"] = args.autotune_max_mem
-                        if args.autotune_min_disk is not None or args.autotune_max_disk is not None:
+                                instance_config["autotune"]["mem"][
+                                    "max"
+                                ] = args.autotune_max_mem
+                        if (
+                            args.autotune_min_disk is not None
+                            or args.autotune_max_disk is not None
+                        ):
                             instance_config["autotune"]["disk"] = {}
                             if args.autotune_min_disk is not None:
-                                instance_config["autotune"]["disk"]["min"] = args.autotune_min_disk
+                                instance_config["autotune"]["disk"][
+                                    "min"
+                                ] = args.autotune_min_disk
                             if args.autotune_max_disk is not None:
-                                instance_config["autotune"]["disk"]["max"] = args.autotune_max_disk
+                                instance_config["autotune"]["disk"][
+                                    "max"
+                                ] = args.autotune_max_disk
                     # If the service config does not contain definitions for the shard in each ecosystem
                     # Add the missing definition and write to the corresponding config
                     if args.shard_name not in config_file.keys():

--- a/paasta_tools/contrib/service_shard_update.py
+++ b/paasta_tools/contrib/service_shard_update.py
@@ -63,14 +63,12 @@ def parse_args():
         "--min-instance-count",
         help="If a deploy group is added, the min_instance count to create it with",
         required=False,
-        default=1,
         dest="min_instance_count",
     )
     parser.add_argument(
         "--prod-max-instance-count",
         help="If a deploy group is added, the prod max_instance count to create it with",
         required=False,
-        default=100,
         type=int,
         dest="prod_max_instance_count",
     )
@@ -78,7 +76,6 @@ def parse_args():
         "--non-prod-max-instance-count",
         help="If a deploy group is added, the non-prod max_instance count to create it with",
         required=False,
-        default=5,
         type=int,
         dest="non_prod_max_instance_count",
     )
@@ -243,14 +240,28 @@ def main(args):
 
                     instance_config = {
                         "deploy_group": f"{deploy_prefix}.{args.shard_name}",
-                        "min_instances": args.min_instance_count,
-                        "max_instances": args.prod_max_instance_count
-                        if deploy_prefix == "prod"
-                        else args.non_prod_max_instance_count,
                         "env": {
                             "PAASTA_SECRET_BUGSNAG_API_KEY": "SECRET(bugsnag_api_key)",
                         },
                     }
+
+                    if args.min_instance_count is not None:
+                        instance_config["min_instances"] = args.min_instance_count
+
+                    if (
+                        args.prod_max_instance_count is not None
+                        and deploy_prefix == "prod"
+                    ):
+                        instance_config["max_instances"] = args.prod_max_instance_count
+
+                    if (
+                        args.non_prod_max_instance_count is not None
+                        and deploy_prefix != "prod"
+                    ):
+                        instance_config[
+                            "max_instances"
+                        ] = args.non_prod_max_instance_count
+
                     if args.metrics_provider is not None or args.setpoint is not None:
                         instance_config["autoscaling"] = {}
                         if args.metrics_provider is not None:

--- a/paasta_tools/contrib/service_shard_update.py
+++ b/paasta_tools/contrib/service_shard_update.py
@@ -40,6 +40,13 @@ def parse_args():
         dest="verbose",
     )
     parser.add_argument(
+        "-d",
+        "--dry-run",
+        help="Do not commit changes to git",
+        action="store_true",
+        dest="dry_run",
+    )
+    parser.add_argument(
         "--source-id",
         help="String to attribute the changes in the commit message.",
         required=False,
@@ -114,6 +121,48 @@ def parse_args():
         required=False,
         type=int,
         dest="timeout_server_ms",
+    )
+    parser.add_argument(
+        "--autotune-min-cpus",
+        help="Minimum number of CPUs Autotune should give the shard",
+        required=False,
+        type=float,
+        dest="autotune_min_cpus",
+    )
+    parser.add_argument(
+        "--autotune-max-cpus",
+        help="Maximum number of CPUs Autotune should give the shard",
+        required=False,
+        type=float,
+        dest="autotune_max_cpus",
+    )
+    parser.add_argument(
+        "--autotune-min-mem",
+        help="Minimum amount of memory Autotune should give the shard",
+        required=False,
+        type=int,
+        dest="autotune_min_mem",
+    )
+    parser.add_argument(
+        "--autotune-max-mem",
+        help="Maximum amount of memory Autotune should give the shard",
+        required=False,
+        type=int,
+        dest="autotune_max_mem",
+    )
+    parser.add_argument(
+        "--autotune-min-disk",
+        help="Minimum amount of disk Autotune should give the shard",
+        required=False,
+        type=int,
+        dest="autotune_min_disk",
+    )
+    parser.add_argument(
+        "--autotune-max-disk",
+        help="Maximum amount of disk Autotune should give the shard",
+        required=False,
+        type=int,
+        dest="autotune_max_disk",
     )
     return parser.parse_args()
 
@@ -214,6 +263,26 @@ def main(args):
                         instance_config["cpus"] = args.cpus
                     if args.mem is not None:
                         instance_config["mem"] = args.mem
+                    if any((args.autotune_min_cpus, args.autotune_max_cpus, args.autotune_min_mem, args.autotune_max_mem, args.autotune_min_disk, args.autotune_max_disk)):
+                        instance_config["autotune"] = {}
+                        if args.autotune_min_cpus is not None or args.autotune_max_cpus is not None:
+                            instance_config["autotune"]["cpus"] = {}
+                            if args.autotune_min_cpus is not None:
+                                instance_config["autotune"]["cpus"]["min"] = args.autotune_min_cpus
+                            if args.autotune_max_cpus is not None:
+                                instance_config["autotune"]["cpus"]["max"] = args.autotune_max_cpus
+                        if args.autotune_min_mem is not None or args.autotune_max_mem is not None:
+                            instance_config["autotune"]["mem"] = {}
+                            if args.autotune_min_mem is not None:
+                                instance_config["autotune"]["mem"]["min"] = args.autotune_min_mem
+                            if args.autotune_max_mem is not None:
+                                instance_config["autotune"]["mem"]["max"] = args.autotune_max_mem
+                        if args.autotune_min_disk is not None or args.autotune_max_disk is not None:
+                            instance_config["autotune"]["disk"] = {}
+                            if args.autotune_min_disk is not None:
+                                instance_config["autotune"]["disk"]["min"] = args.autotune_min_disk
+                            if args.autotune_max_disk is not None:
+                                instance_config["autotune"]["disk"]["max"] = args.autotune_max_disk
                     # If the service config does not contain definitions for the shard in each ecosystem
                     # Add the missing definition and write to the corresponding config
                     if args.shard_name not in config_file.keys():
@@ -244,7 +313,7 @@ def main(args):
             log.info(f"{args.shard_name} is in smartstack config already, skipping.")
 
         # Only commit to remote if changes were made
-        if changes_made:
+        if changes_made and not args.dry_run:
             updater.commit_to_remote()
             trigger_deploys(args.service)
         else:


### PR DESCRIPTION
Added to PaaSTA at large in #3744. Also pulls in commit from #3829 to make min/max instance values optional and adds a new `--dry-run` param that skips committing and pushing changes to yelpsoa-configs.

Confirmed that the new kwargs do as expected, generating valid configs. If anyone knows a way to do this that doesn't involve a mess of nested if statements, I'm all ears lol